### PR TITLE
Clean Nulls Option. Skip Thornton if all NaN.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -66,6 +66,13 @@ fill_option = 0
 #	Set this to 1 to generate bokeh plots
 plot_option = 1
 
+##########
+# Clean Null Characters - This option determines whether or not we first sanitize null characters (\x00) from your input
+# file. This causes a slight increase in processing time, and higher memory consumption.
+#	Set this to 0 to not clean null characters
+#	Set this to 1 to clean null characters
+clean_nulls = 0
+
 [DATA]
 ##########
 # Data Organization


### PR DESCRIPTION
Hi!

Was running this script against some station data from Wyomings WACNET (http://www.wrds.uwyo.edu/WACNet/Stations.html).

Included here are two proposed fixes I needed to make locally in order to complete a full run.

**Fix #1** is the addition of a configuration option "clean_nulls". If set to 1 the input file is read, and all null characters (\x00) are replaced with empty strings.

An alternative solution would be to set 'engine=c' on the pandas parser (this also worked in testing). However when reading the pandas documentation at https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html they mention "The C engine is faster while the python engine is currently more feature-complete."

I don't know what all parsing features are being used. So manually removing null bytes seemed like the safer option.

Fix #2 has to do with the running of the thornton-running stuff in the "calc_org_and_opt_rs_tr" function. In my case it was failing due to every single number in the "mc_rmse" array being NaN (numpy ValueError all-NaN slice).

Feel free to tell me also if this one was just a mis-configuration on my part.

I don't really have a fix for this. But what I did was surround with try/catch so that the script can continue. This allowed me to finish generating my before_graphs. However the bottom two RH graphs were blank due to the skipped step.

Happy to make any changes if you'd like. Mostly thought I'd just offer back the things I needed to change to get this to run for me.

Thanks!